### PR TITLE
sirius: use specific idProduct for usb paths

### DIFF
--- a/aosp_d6503.mk
+++ b/aosp_d6503.mk
@@ -77,4 +77,5 @@ PRODUCT_AAPT_PREBUILT_DPI := xxhdpi xhdpi hdpi
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi
 
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.sf.lcd_density=480
+    ro.sf.lcd_density=480 \
+    ro.usb.pid_suffix=1AF


### PR DESCRIPTION
from 23.0.1.A.0.167

Signed-off-by: David Viteri <davidteri91@gmail.com>