### PR TITLE
Enable simple PowerHAL for native double-tap-to-wake

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -22,3 +22,6 @@ BOARD_USERDATAIMAGE_PARTITION_SIZE := 12656242688
 #BOARD_KERNEL_CMDLINE += mem=2690M@255M
 
 PRODUCT_VENDOR_KERNEL_HEADERS += device/sony/sirius/kernel-headers
+
+TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/max1187x/power/wakeup"
+TARGET_TAP_TO_WAKE_STRING := true


### PR DESCRIPTION
Signed-off-by: Adam Farden <adam@farden.cz>