### PR TITLE
sirius: Update NFC NXP HAL naming

### DIFF
--- a/aosp_d6503.mk
+++ b/aosp_d6503.mk
@@ -67,6 +67,10 @@ PRODUCT_COPY_FILES += \
     device/sony/sirius/rootdir/system/etc/tfa98xx/VoiceCallEarpice_top.preset:/system/etc/tfa98xx/VoiceCallEarpice_top.preset \
     device/sony/sirius/rootdir/system/etc/tfa98xx/VoiceCallEarpice_top.eq:/system/etc/tfa98xx/VoiceCallEarpice_top.eq
 
+# NFC config
+PRODUCT_PACKAGES += nfc_nci.sirius
+ADDITIONAL_DEFAULT_PROPERTIES += ro.hardware.nfc_nci=sirius
+
 PRODUCT_NAME := aosp_d6503
 PRODUCT_DEVICE := sirius
 PRODUCT_MODEL := Xperia Z2 (AOSP)


### PR DESCRIPTION
This patch just uses AOSP directives by updating NFC HAL name
using the device name and declares the additional property "ro.hardware.nfc_nci"
to default.prop. So it fixes hw_get_module process.

AOSP uses $(TARGET_DEVICE) as NFC HAL composition naming
as commented here:

https://android-review.googlesource.com/#/c/155054/

By: Thierry Strudel

TARGET_BOARD_PLATFORM is set to the SoC name of a product
and the NFC chip has no relation to it.
TARGET_DEVICE is the only variable fully defining the device
and so selecting an HW device appropriately.
Given it should be easy to update PRODUCT_PACKAGES of any legacy device

Signed-off-by: Humberto Borba <humberos@gmail.com>