### PR TITLE
thermanager: rewrite config to match kitakami style

### DIFF
--- a/rootdir/system/etc/thermanager.xml
+++ b/rootdir/system/etc/thermanager.xml
@@ -1,19 +1,44 @@
 <thermanager>
 	<resources>
 		<!-- thermal zones -->
-		<resource name="zone0" type="tz">/sys/class/thermal/thermal_zone0</resource>
-		<resource name="zone1" type="tz">/sys/class/thermal/thermal_zone1</resource>
-		<resource name="zone2" type="tz">/sys/class/thermal/thermal_zone2</resource>
-		<resource name="zone3" type="tz">/sys/class/thermal/thermal_zone3</resource>
-		<resource name="zone4" type="tz">/sys/class/thermal/thermal_zone4</resource>
-		<resource name="zone5" type="tz">/sys/class/thermal/thermal_zone5</resource>
-		<resource name="zone6" type="tz">/sys/class/thermal/thermal_zone6</resource>
-		<resource name="zone7" type="tz">/sys/class/thermal/thermal_zone7</resource>
-		<resource name="zone8" type="tz">/sys/class/thermal/thermal_zone8</resource>
-		<resource name="zone9" type="tz">/sys/class/thermal/thermal_zone9</resource>
-		<resource name="zone10" type="tz">/sys/class/thermal/thermal_zone10</resource>
-		<resource name="zone11" type="tz">/sys/class/thermal/thermal_zone11</resource>
-		<resource name="zone12" type="tz">/sys/class/thermal/thermal_zone12</resource>
+		<resource name="tsens_tz_sensor0"  type="tz">/sys/class/thermal/thermal_zone0</resource>
+		<resource name="tsens_tz_sensor1"  type="tz">/sys/class/thermal/thermal_zone1</resource>
+		<resource name="tsens_tz_sensor2"  type="tz">/sys/class/thermal/thermal_zone2</resource>
+		<resource name="tsens_tz_sensor3"  type="tz">/sys/class/thermal/thermal_zone3</resource>
+		<resource name="tsens_tz_sensor4"  type="tz">/sys/class/thermal/thermal_zone4</resource>
+		<resource name="tsens_tz_sensor5"  type="tz">/sys/class/thermal/thermal_zone5</resource>  <!-- cpu0 -->
+		<resource name="tsens_tz_sensor6"  type="tz">/sys/class/thermal/thermal_zone6</resource>  <!-- cpu1 -->
+		<resource name="tsens_tz_sensor7"  type="tz">/sys/class/thermal/thermal_zone7</resource>  <!-- cpu2 -->
+		<resource name="tsens_tz_sensor8"  type="tz">/sys/class/thermal/thermal_zone8</resource>  <!-- cpu3 -->
+		<resource name="tsens_tz_sensor9"  type="tz">/sys/class/thermal/thermal_zone9</resource>  <!-- gpu0 -->
+		<resource name="tsens_tz_sensor10" type="tz">/sys/class/thermal/thermal_zone10</resource> <!-- gpu1 -->
+
+		<resource name="pm8941_tz" type="tz">/sys/class/thermal/thermal_zone12</resource>
+		<resource name="pa_therm0" type="tz">/sys/class/thermal/thermal_zone13</resource>
+		<resource name="pa_therm1" type="tz">/sys/class/thermal/thermal_zone14</resource>
+		<resource name="emmc_therm" type="tz">/sys/class/thermal/thermal_zone15</resource>
+		<resource name="msm_therm" type="tz">/sys/class/thermal/thermal_zone16</resource>
+		<resource name="battery" type="tz">/sys/class/thermal/thermal_zone17</resource>
+
+		<resource name="temp-core" type="union">
+			<resource name="tsens_tz_sensor0" />
+			<resource name="tsens_tz_sensor1" />
+			<resource name="tsens_tz_sensor2" />
+			<resource name="tsens_tz_sensor3" />
+			<resource name="tsens_tz_sensor4" />
+		</resource>
+
+		<resource name="temp-cluster-krait" type="union">
+			<resource name="tsens_tz_sensor5" />
+			<resource name="tsens_tz_sensor6" />
+			<resource name="tsens_tz_sensor7" />
+			<resource name="tsens_tz_sensor8" />
+		</resource>
+
+		<resource name="temp-adreno-320" type="union">
+			<resource name="tsens_tz_sensor9"  />
+			<resource name="tsens_tz_sensor10" />
+		</resource>
 
 		<!-- generic cpufreq -->
 		<resource name="cpu0" type="sysfs">/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq</resource>
@@ -21,7 +46,7 @@
 		<resource name="cpu2" type="sysfs">/sys/devices/system/cpu/cpu2/cpufreq/scaling_max_freq</resource>
 		<resource name="cpu3" type="sysfs">/sys/devices/system/cpu/cpu3/cpufreq/scaling_max_freq</resource>
 
-		<resource name="cpu" type="union">
+		<resource name="cluster-krait" type="union">
 			<resource name="cpu0" />
 			<resource name="cpu1" />
 			<resource name="cpu2" />
@@ -29,31 +54,12 @@
 		</resource>
 
 		<!-- device-specific -->
-		<resource name="backlight" type="sysfs">/sys/class/leds/lcd-backlight/max_brightness</resource>
-		
-		<resource name="charger" type="sysfs">/sys/class/power_supply/battery/system_temp_level</resource>
-		<resource name="charge_en" type="sysfs">/sys/class/power_supply/battery/charging_enabled</resource>
-		<resource name="dc" type="sysfs">/sys/class/power_supply/qpnp-dc/current_max</resource>
-		<resource name="temp-batt" type="msm-adc">/sys/devices/00-vadc-3100/batt_therm</resource>
-		<resource name="temp-emmc" type="msm-adc">/sys/devices/00-vadc-3100/emmc_therm</resource>
 		<resource name="kgsl-3d0" type="sysfs">/sys/class/kgsl/kgsl-3d0/max_gpuclk</resource>
-		<resource name="temp-core" type="alias" resource="zone2" />
 		<resource name="usb" type="sysfs">/sys/class/power_supply/usb/current_max</resource>
-
-		<resource name="temp-gpu" type="union">
-			<resource name="zone9" />
-			<resource name="zone10" />
-		</resource>
-
-		<resource name="temp-cpu" type="union">
-			<resource name="zone5" />
-			<resource name="zone6" />
-			<resource name="zone7" />
-			<resource name="zone8" />
-		</resource>
+		<resource name="charge_speed" type="sysfs">/sys/class/power_supply/battery/system_temp_level</resource>
+		<resource name="charging_enabled" type="sysfs">/sys/class/power_supply/battery/charging_enabled</resource>
 
 		<!-- TODO: -->
-		<resource name="camera" type="echo" />
 		<resource name="modem" type="echo" />
 
 		<resource name="shutdown" type="halt" delay="5" />
@@ -69,33 +75,23 @@
 		<mitigation level="6"><value resource="usb">150000</value></mitigation>
 	</control>
 
-	<control name="dc">
-		<mitigation level="off"><value resource="dc">1800000</value></mitigation>
-		<mitigation level="1"><value resource="dc">1100000</value></mitigation>
-		<mitigation level="2"><value resource="dc">900000</value></mitigation>
-		<mitigation level="3"><value resource="dc">700000</value></mitigation>
-		<mitigation level="4"><value resource="dc">500000</value></mitigation>
-		<mitigation level="5"><value resource="dc">300000</value></mitigation>
-		<mitigation level="6"><value resource="dc">150000</value></mitigation>
-	</control>
-
-	<control name="charge_en">
-		<mitigation level="off"><value resource="charge_en">1</value></mitigation>
-		<mitigation level="1"><value resource="charge_en">0</value></mitigation>
+	<control name="battery_protect">
+		<mitigation level="off"><value resource="charging_enabled">1</value></mitigation>
+		<mitigation level="1"><value resource="charging_enabled">0</value></mitigation>
 		<mitigation level="2"><value resource="shutdown" /></mitigation>
 	</control>
 
 	<control name="charging">
-		<mitigation level="off"><value resource="charger">0</value></mitigation>
-		<mitigation level="1"><value resource="charger">1</value></mitigation>
-		<mitigation level="2"><value resource="charger">2</value></mitigation>
-		<mitigation level="3"><value resource="charger">3</value></mitigation>
-		<mitigation level="4"><value resource="charger">4</value></mitigation>
-		<mitigation level="5"><value resource="charger">5</value></mitigation>
-		<mitigation level="6"><value resource="charger">6</value></mitigation>
-		<mitigation level="7"><value resource="charger">7</value></mitigation>
-		<mitigation level="8"><value resource="charger">8</value></mitigation>
-		<mitigation level="9"><value resource="charger">9</value></mitigation>
+		<mitigation level="off"><value resource="charge_speed">0</value></mitigation>
+		<mitigation level="1"><value resource="charge_speed">1</value></mitigation>
+		<mitigation level="2"><value resource="charge_speed">2</value></mitigation>
+		<mitigation level="3"><value resource="charge_speed">3</value></mitigation>
+		<mitigation level="4"><value resource="charge_speed">4</value></mitigation>
+		<mitigation level="5"><value resource="charge_speed">5</value></mitigation>
+		<mitigation level="6"><value resource="charge_speed">6</value></mitigation>
+		<mitigation level="7"><value resource="charge_speed">7</value></mitigation>
+		<mitigation level="8"><value resource="charge_speed">8</value></mitigation>
+		<mitigation level="9"><value resource="charge_speed">9</value></mitigation>
 	</control>
 
 	<control name="modem">
@@ -103,54 +99,35 @@
 		<mitigation level="1"><value resource="modem">1</value></mitigation>
 	</control>
 
-	<control name="camera">
-		<mitigation level="off"><value resource="camera">NORMAL</value></mitigation>
-		<mitigation level="1"><value resource="camera">WARNING</value></mitigation>
-		<mitigation level="2"><value resource="camera">CRITICAL</value></mitigation>
-	</control>
-
 	<control name="shutdown">
 		<mitigation level="off" />
-		<mitigation level="1"><value resource="shutdown" /></mitigation>
-	</control>
-
-	<control name="backlight">
-		<mitigation level="off"><value resource="backlight">255</value></mitigation>
-		<mitigation level="1"><value resource="backlight">223</value></mitigation>
-		<mitigation level="2"><value resource="backlight">192</value></mitigation>
-		<mitigation level="3"><value resource="backlight">160</value></mitigation>
-		<mitigation level="4"><value resource="backlight">128</value></mitigation>
-		<mitigation level="5"><value resource="backlight">107</value></mitigation>
-		<mitigation level="6"><value resource="backlight">88</value></mitigation>
-		<mitigation level="7"><value resource="backlight">64</value></mitigation>
-		<mitigation level="8"><value resource="backlight">57</value></mitigation>
-		<mitigation level="9"><value resource="backlight">51</value></mitigation>
+		<mitigation level="1"><value resource="shutdown"/></mitigation>
 	</control>
 
 	<control name="gpu">
-		<mitigation level="off"><value resource="gpu">578000000</value></mitigation>
-		<mitigation level="1"><value resource="gpu">462400000</value></mitigation>
-		<mitigation level="2"><value resource="gpu">389000000</value></mitigation>
-		<mitigation level="3"><value resource="gpu">330000000</value></mitigation>
-		<mitigation level="4"><value resource="gpu">200000000</value></mitigation>
+		<mitigation level="off"><value resource="kgsl-3d0">578000000</value></mitigation>
+		<mitigation level="1"><value resource="kgsl-3d0">462400000</value></mitigation>
+		<mitigation level="2"><value resource="kgsl-3d0">389000000</value></mitigation>
+		<mitigation level="3"><value resource="kgsl-3d0">330000000</value></mitigation>
+		<mitigation level="4"><value resource="kgsl-3d0">200000000</value></mitigation>
 		<mitigation level="5"><value resource="shutdown" /></mitigation>
 	</control>
 
-	<control name="cpu">
-		<mitigation level="off"><value resource="cpu">2265600</value></mitigation>
-		<mitigation level="1"><value resource="cpu">1958400</value></mitigation>
-		<mitigation level="2"><value resource="cpu">1728000</value></mitigation>
-		<mitigation level="3"><value resource="cpu">1574400</value></mitigation>
-		<mitigation level="4"><value resource="cpu">1497600</value></mitigation>
-		<mitigation level="5"><value resource="cpu">1267200</value></mitigation>
-		<mitigation level="6"><value resource="cpu">1190400</value></mitigation>
-		<mitigation level="7"><value resource="cpu">1036800</value></mitigation>
-		<mitigation level="8"><value resource="cpu">960000</value></mitigation>
-		<mitigation level="9"><value resource="cpu">883200</value></mitigation>
-		<mitigation level="10"><value resource="cpu">729600</value></mitigation>
-		<mitigation level="11"><value resource="cpu">652800</value></mitigation>
-		<mitigation level="12"><value resource="cpu">422400</value></mitigation>
-		<mitigation level="13"><value resource="cpu">300000</value></mitigation>
+	<control name="cpu-krait">
+		<mitigation level="off"><value resource="cluster-krait">2265600</value></mitigation>
+		<mitigation level="1"><value resource="cluster-krait">1958400</value></mitigation>
+		<mitigation level="2"><value resource="cluster-krait">1728000</value></mitigation>
+		<mitigation level="3"><value resource="cluster-krait">1574400</value></mitigation>
+		<mitigation level="4"><value resource="cluster-krait">1497600</value></mitigation>
+		<mitigation level="5"><value resource="cluster-krait">1267200</value></mitigation>
+		<mitigation level="6"><value resource="cluster-krait">1190400</value></mitigation>
+		<mitigation level="7"><value resource="cluster-krait">1036800</value></mitigation>
+		<mitigation level="8"><value resource="cluster-krait">960000</value></mitigation>
+		<mitigation level="9"><value resource="cluster-krait">883200</value></mitigation>
+		<mitigation level="10"><value resource="cluster-krait">729600</value></mitigation>
+		<mitigation level="11"><value resource="cluster-krait">652800</value></mitigation>
+		<mitigation level="12"><value resource="cluster-krait">422400</value></mitigation>
+		<mitigation level="13"><value resource="cluster-krait">300000</value></mitigation>
 		<mitigation level="14"><value resource="shutdown" /></mitigation>
 	</control>
 
@@ -159,111 +136,146 @@
 		<threshold>
 			<mitigation name="shutdown" level="off" />
 		</threshold>
-		<threshold trigger="120" clear="115">
+		<threshold trigger="120" clear="100">
 			<mitigation name="shutdown" level="1" />
 		</threshold>
 	</configuration>
 
-	<!-- usb, dc, charging, modem,backlight -->
-	<configuration sensor="temp-emmc">
+	<!-- USB and DC -->
+	<configuration sensor="pm8941_tz">
 		<threshold>
-			<mitigation name="dc" level="off" />
 			<mitigation name="usb" level="off" />
-			<mitigation name="charging" level="off" />
-			<mitigation name="modem" level="off" />
-			<mitigation name="backlight" level="off" />
 		</threshold>
-		<threshold trigger="510" clear="500">
-			<mitigation name="dc" level="2" />
+		<threshold trigger="51000" clear="50000">
 			<mitigation name="usb" level="2" />
-			<mitigation name="charging" level="5" />
-			<mitigation name="backlight" level="1" />
 		</threshold>
-		<threshold trigger="525" clear="510">
-			<mitigation name="dc" level="3" />
+		<threshold trigger="52500" clear="51000">
 			<mitigation name="usb" level="3" />
-			<mitigation name="backlight" level="2" />
 		</threshold>
-		<threshold trigger="540" clear="525">
-			<mitigation name="dc" level="4" />
+		<threshold trigger="54000" clear="52500">
 			<mitigation name="usb" level="4" />
-			<mitigation name="charging" level="7" />
-			<mitigation name="backlight" level="3" />
 		</threshold>
-		<threshold trigger="555" clear="540">
-			<mitigation name="backlight" level="4" />
-		</threshold>
-		<threshold trigger="570" clear="545">
-			<mitigation name="dc" level="4" />
+		<threshold trigger="57000" clear="54500">
 			<mitigation name="usb" level="4" />
-			<mitigation name="backlight" level="5" />
 		</threshold>
-		<threshold trigger="580" clear="555">
-			<mitigation name="backlight" level="6" />
-		</threshold>
-		<threshold trigger="585" clear="560">
-			<mitigation name="dc" level="4" />
+		<threshold trigger="58500" clear="56000">
 			<mitigation name="usb" level="4" />
-			<mitigation name="charging" level="8" />
-			<mitigation name="modem" level="1" />
-			<mitigation name="backlight" level="7" />
-		</threshold>
-		<threshold trigger="590" clear="570">
-			<mitigation name="backlight" level="8" />
-		</threshold>
-		<threshold trigger="595" clear="580">
-			<mitigation name="backlight" level="9" />
 		</threshold>
 	</configuration>
 
-	<!-- Charging -->
-	<configuration sensor="temp-batt">
+	<!-- charging -->
+	<configuration sensor="pm8941_tz">
 		<threshold>
-			<mitigation name="charge_en" level="off" />
+			<mitigation name="charging" level="off" />
 		</threshold>
-		<threshold trigger="464" clear="442">
-			<mitigation name="charge_en" level="1" />
+		<threshold trigger="52500" clear="49500">
+			<mitigation name="charging" level="5" />
 		</threshold>
-		<threshold trigger="800" clear="780">
-			<mitigation name="charge_en" level="2" />
+		<threshold trigger="55500" clear="52500">
+			<mitigation name="charging" level="7" />
+		</threshold>
+		<threshold trigger="59500" clear="57000">
+			<mitigation name="charging" level="8" />
+		</threshold>
+	</configuration>
+
+	<configuration sensor="battery">
+		<threshold>
+			<mitigation name="battery_protect" level="off" />
+		</threshold>
+		<threshold trigger="45000" clear="40000">
+			<mitigation name="battery_protect" level="1" />
+		</threshold>
+		<threshold trigger="70000" clear="65000">
+			<mitigation name="battery_protect" level="2" />
 		</threshold>
 	</configuration>
 
 	<!-- GPU -->
-	<configuration sensor="temp-gpu">
+	<configuration sensor="emmc_therm">
 		<threshold>
 			<mitigation name="gpu" level="off" />
 		</threshold>
-		<threshold trigger="100" clear="95">
+		<threshold trigger="595" clear="570">
 			<mitigation name="gpu" level="4" />
 		</threshold>
-		<threshold trigger="120" clear="110">
+		<threshold trigger="870" clear="630">
 			<mitigation name="gpu" level="5" />
 		</threshold>
 	</configuration>
 
-	<!-- CPU -->
-	<configuration sensor="temp-cpu">
+	<configuration sensor="temp-adreno-320">
 		<threshold>
-			<mitigation name="cpu" level="off" />
+			<mitigation name="gpu" level="off" />
 		</threshold>
-		<threshold trigger="80" clear="75">
-			<mitigation name="cpu" level="2" />
+		<threshold trigger="100" clear="70">
+			<mitigation name="gpu" level="4" />
 		</threshold>
-		<threshold trigger="85" clear="80">
-			<mitigation name="cpu" level="3" />
-		</threshold>
-		<threshold trigger="90" clear="85">
-			<mitigation name="cpu" level="4" />
-		</threshold>
-		<threshold trigger="95" clear="90">
-			<mitigation name="cpu" level="9" />
-		</threshold>
-		<threshold trigger="110" clear="95">
-			<mitigation name="cpu" level="12" />
-		</threshold>
-		<threshold trigger="120" clear="115">
-			<mitigation name="cpu" level="14" />
+		<threshold trigger="120" clear="95">
+			<mitigation name="gpu" level="5" />
 		</threshold>
 	</configuration>
+
+	<!-- modem -->
+	<configuration sensor="emmc_therm">
+		<threshold>
+			<mitigation name="modem" level="off" />
+		</threshold>
+		<threshold trigger="580" clear="545">
+			<mitigation name="modem" level="1" />
+		</threshold>
+	</configuration>
+
+	<!-- CPU -->
+	<configuration sensor="emmc_therm">
+		<threshold>
+			<mitigation name="cpu-krait" level="off" />
+		</threshold>
+		<threshold trigger="570" clear="540">
+			<mitigation name="cpu-krait" level="2" />
+		</threshold>
+		<threshold trigger="580" clear="545">
+			<mitigation name="cpu-krait" level="5" />
+		</threshold>
+		<threshold trigger="585" clear="555">
+			<mitigation name="cpu-krait" level="7" />
+		</threshold>
+		<threshold trigger="590" clear="560">
+			<mitigation name="cpu-krait" level="9" />
+		</threshold>
+		<threshold trigger="595" clear="570">
+			<mitigation name="cpu-krait" level="10" />
+		</threshold>
+		<threshold trigger="600" clear="580">
+			<mitigation name="cpu-krait" level="11" />
+		</threshold>
+		<threshold trigger="685" clear="590">
+			<mitigation name="cpu-krait" level="12" />
+		</threshold>
+		<threshold trigger="870" clear="630">
+			<mitigation name="cpu-krait" level="14" />
+		</threshold>
+	</configuration>
+
+	<configuration sensor="temp-cluster-krait">
+		<threshold>
+			<mitigation name="cpu-krait" level="off" />
+		</threshold>
+		<threshold trigger="80" clear="60">
+			<mitigation name="cpu-krait" level="2" />
+		</threshold>
+		<threshold trigger="90" clear="65">
+			<mitigation name="cpu-krait" level="4" />
+		</threshold>
+		<threshold trigger="95" clear="75">
+			<mitigation name="cpu-krait" level="9" />
+		</threshold>
+		<threshold trigger="110" clear="80">
+			<mitigation name="cpu-krait" level="12" />
+		</threshold>
+		<threshold trigger="120" clear="100">
+			<mitigation name="cpu-krait" level="14" />
+		</threshold>
+	</configuration>
+
 </thermanager>


### PR DESCRIPTION
* remove unused parts (brightness related)
* use actual thermal sensors (emmc_therm etc)
* use actual values from stock config
* seperate parts for clarity and for easy updates
* rename resources for clarity

Signed-off-by: Adam Farden <adam@farden.cz>