### PR TITLE
Update nfc config for working NFC

### DIFF
--- a/rootdir/system/etc/libnfc-nxp.conf
+++ b/rootdir/system/etc/libnfc-nxp.conf
@@ -31,7 +31,7 @@ MIFARE_READER_ENABLE=0x01
 # System clock source selection configuration
 #    CLK_SRC_XTAL     - 0x01
 #    CLK_SRC_PLL      - 0x02
-NXP_SYS_CLK_SRC_SEL=0x02
+NXP_SYS_CLK_SRC_SEL=0x01
 
 ###############################################################################
 # System clock frequency selection configuration for PLL


### PR DESCRIPTION
Use the clock source setting from castor_windy, where NFC works properly.
With the old config value, NFC switch only appears with the USB cable plugged,
and NFC is constantly crashing, involving libc crashes which randomly
causes system reboots (soft & hard reboots).

Main differences to make NFC "work" on sirius:
NXP_SYS_CLK_SRC_SEL=0x02 --> 0x01

This commit is a result of a collaborative effort with Max Weffers.

Verified-by: Max Weffers <rcstar6696@gmail.com>
Signed-off-by: Alexander Diewald <Diewi@diewald-net.com>